### PR TITLE
Added X-Drone-Branches Filter

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -60,6 +60,15 @@ func (p *plugin) Find(ctx context.Context, req *secret.Request) (*drone.Secret, 
 		return nil, errors.New("access denied: repository does not match")
 	}
 
+	// the user can filter out requets based on repository
+	// branch using the X-Drone-Branches secret key. Check
+	// for this user-defined filter logic.
+	branches := extractBranches(params)
+	if !match(req.Build.Target, branches) {
+		return nil, errors.New("access denied: branch does not match")
+	}
+
+
 	return &drone.Secret{
 		Data: value,
 		Pull: true, // always true. use X-Drone-Events to prevent pull requests.

--- a/plugin/testdata/secret.json
+++ b/plugin/testdata/secret.json
@@ -1,5 +1,5 @@
 {
-  "ARN":"arn:aws:secretsmanager:us-east-1:123456789012:secret:docker",
-  "Name":"docker",
-  "SecretString":"{\n  \"username\":\"david\",\n  \"password\":\"BnQw&XDWgaEeT9XGTT29\",\n  \"X-Drone-Repos\":\"octocat/*\", \"X-Drone-Events\":\"tag,push\" \n}\n"
+  "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:docker",
+  "Name": "docker",
+  "SecretString": "{\n  \"username\":\"david\",\n  \"password\":\"BnQw&XDWgaEeT9XGTT29\",\n  \"X-Drone-Repos\":\"octocat/*\", \"X-Drone-Events\":\"tag,push\", \"X-Drone-Branches\":\"master\" \n}\n"
 }

--- a/plugin/util.go
+++ b/plugin/util.go
@@ -6,6 +6,17 @@ package plugin
 
 import "strings"
 
+// helper function extracts the branch filters from the
+// secret payload in key value format.
+func extractBranches(params map[string]string) []string {
+	for key, value := range params {
+		if strings.EqualFold(key, "X-Drone-Branches") {
+			return parseCommaSeparated(value)
+		}
+	}
+	return nil
+}
+
 // helper function extracts the repository filters from the
 // secret payload in key value format.
 func extractRepos(params map[string]string) []string {

--- a/plugin/util_test.go
+++ b/plugin/util_test.go
@@ -9,6 +9,41 @@ import (
 	"testing"
 )
 
+func TestExtractBranches(t *testing.T) {
+	tests := []struct {
+		params   map[string]string
+		patterns []string
+	}{
+		{
+			params:   map[string]string{"X-Drone-Branches": ""},
+			patterns: nil,
+		},
+		{
+			params:   map[string]string{"X-Drone-Branches": "master"},
+			patterns: []string{"master"},
+		},
+		{
+			params:   map[string]string{"X-Drone-Branches": "master,development"},
+			patterns: []string{"master", "development"},
+		},
+		{
+			params:   map[string]string{"x-drone-branches": "master,development"},
+			patterns: []string{"master", "development"},
+		},
+		{
+			params:   map[string]string{"foo": "bar"},
+			patterns: nil,
+		},
+	}
+
+	for i, test := range tests {
+		got, want := extractBranches(test.params), test.patterns
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("Unexpected results at %d", i)
+		}
+	}
+}
+
 func TestExtractRepos(t *testing.T) {
 	tests := []struct {
 		params   map[string]string


### PR DESCRIPTION
Simply porting the implementation from https://github.com/drone/drone-vault/pull/2 to here. All credits to @null93

Here's the description for Vault:

### Description
The following pull request extends the current functionality of the drone-amazon-secrets extension. In particular a new filter type was added. In addition to `X-Drone-Repos` and `X-Drone-Events`, `X-Drone-Branches` can now be specified. When a pipeline is triggered, the target branch will be used for filtering. This pull request also extends the test suite to ensure proper functionality of this newly added filter type.

### Use Case
Lets assume we have a simple CD process:

* When pushing to the `master` branch, build docker image and push to a private production docker registry.
* When pushing to the `development` branch, build docker image and push to a private development docker registry.
* Using protected branches on Github, protect pushes to `master` branch to allow only trusted people to push to it.

The above assumes that we store the production docker images separate from all other ones because they either might contain production grade information or we do not want anyone with push privileges to the development branch to override an image. An example could be an SSL cert baked into the docker image. Our goal is not to let people who have push privileges to the development branch be able to push their image to the production private registry.

Assume that the following information is stored within AWS Secrets:

```
docker-registry/data/production/registry_username=prod-username
docker-registry/data/production/registry_password=prod-password
docker-registry/data/production/x-drone-repos=foo/*
docker-registry/data/production/x-drone-events=push
docker-registry/data/development/registry_username=dev-username
docker-registry/data/development/registry_password=dev-password
docker-registry/data/development/x-drone-repos=foo/*
docker-registry/data/development/x-drone-events=push
```

Consider the the following Drone configuration:

```yaml
kind: pipeline
name: Development

trigger:
    branch:
    -   development
    event:
    -   push
steps:
-   name: docker-image
    image: plugins/docker
    settings:
        registry: development-registry.example.com
        username:
            from_secret: development_registry_username
        password:
            from_secret: development_registry_password
        repo: development-registry.example.com/foo/bar
        tags: latest

---

kind: pipeline
name: Production

trigger:
    branch:
    -   master
    event:
    -   push
steps:
-   name: docker-image
    image: plugins/docker
    settings:
        registry: production-registry.example.com
        username:
            from_secret: production_registry_username
        password:
            from_secret: production_registry_password
        repo: production-registry.example.com/foo/bar
        tags: latest

---

kind: secret
name: development_registry_username
get:
    path: docker-registry/data/development
    name: registry_username

---

kind: secret
name: development_registry_password
get:
    path: docker-registry/data/development
    name: registry_password

---

kind: secret
name: production_registry_username
get:
    path: docker-registry/data/production
    name: registry_username

---

kind: secret
name: production_registry_password
get:
    path: docker-registry/data/production
    name: registry_password
```

With the current setup, a malicious actor with push privileges to development branch, has access to the production credentials.

### How To Fix This Issue
With this new filter we can eliminate this security risk. Let us now assume that the following information is stored within AWS Secrets:

```
docker-registry/data/production/registry_username=prod-username
docker-registry/data/production/registry_password=prod-password
docker-registry/data/production/x-drone-repos=foo/*
docker-registry/data/production/x-drone-events=push
docker-registry/data/production/x-drone-branches=master
docker-registry/data/development/registry_username=dev-username
docker-registry/data/development/registry_password=dev-password
docker-registry/data/development/x-drone-repos=foo/*
docker-registry/data/development/x-drone-events=push
docker-registry/data/development/x-drone-branches=development
```

This solves the issue because now when the `Development` pipeline is triggered, it does not have access to the production registry secrets.

### Possible Implications
I could not think of any possible negative implications that these changes might cause. If you choose not to use this new filter, then everything works as it did before.

### Additional Information
When filtering, the target branch name is considered. That means that if the event does not have metadata about the target branch (i.e. when event is 'tag'), then permission is not given.
