### PR TITLE
Handle non string value

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -40,7 +40,7 @@ func (p *plugin) Find(ctx context.Context, req *secret.Request) (*drone.Secret, 
 	// to retrieve the secret at the requested path.
 	params, err := p.find(req.Path)
 	if err != nil {
-		return nil, errors.New("secret not found")
+		return nil, err
 	}
 	value := params[req.Name]
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/drone/drone-go/drone"
 	"github.com/drone/drone-go/plugin/secret"
@@ -70,14 +71,15 @@ func (p *plugin) Find(ctx context.Context, req *secret.Request) (*drone.Secret, 
 
 
 	return &drone.Secret{
-		Data: value,
+		Data: fmt.Sprintf("%v", value),
 		Pull: true, // always true. use X-Drone-Events to prevent pull requests.
 		Fork: true, // always true. use X-Drone-Events to prevent pull requests.
 	}, nil
 }
 
 // helper function returns the secret from the aws secrets manager.
-func (p *plugin) find(path string) (map[string]string, error) {
+func (p *plugin) find(path string) (map[string]interface{}, error) {
+	var set map[string]interface{}
 	req := p.manager.GetSecretValueRequest(
 		&secretsmanager.GetSecretValueInput{
 			SecretId: aws.String(path),
@@ -85,13 +87,13 @@ func (p *plugin) find(path string) (map[string]string, error) {
 	)
 	res, err := req.Send()
 	if err != nil {
-		return nil, err
+		return nil, errors.New(fmt.Sprintf("secret not found: %v", err))
 	}
 
 	str := aws.StringValue(res.SecretString)
 	raw := []byte(str)
 
-	set := map[string]string{}
+
 	err = json.Unmarshal(raw, &set)
 	return set, err
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -7,6 +7,7 @@ package plugin
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/drone/drone-go/drone"
@@ -284,7 +285,7 @@ func TestPlugin_NotFound(t *testing.T) {
 		t.Errorf("Expect error")
 		return
 	}
-	if want, got := err.Error(), "secret not found"; got != want {
+	if want, got := "secret not found", err.Error(); strings.Contains(want, got) {
 		t.Errorf("Want error %q, got %q", want, got)
 		return
 	}

--- a/plugin/testdata/secret.json
+++ b/plugin/testdata/secret.json
@@ -1,5 +1,5 @@
 {
   "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:docker",
   "Name": "docker",
-  "SecretString": "{\n  \"username\":\"david\",\n  \"password\":\"BnQw&XDWgaEeT9XGTT29\",\n  \"X-Drone-Repos\":\"octocat/*\", \"X-Drone-Events\":\"tag,push\", \"X-Drone-Branches\":\"master\" \n}\n"
+  "SecretString": "{\n  \"username\":\"david\",\n  \"password\":\"BnQw&XDWgaEeT9XGTT29\",\n  \"port\":5342,\n \"ratio\":0.5,\n  \"X-Drone-Repos\":\"octocat/*\", \"X-Drone-Events\":\"tag,push\", \"X-Drone-Branches\":\"master\" \n}\n"
 }

--- a/plugin/util.go
+++ b/plugin/util.go
@@ -4,11 +4,14 @@
 
 package plugin
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // helper function extracts the branch filters from the
 // secret payload in key value format.
-func extractBranches(params map[string]string) []string {
+func extractBranches(params map[string]interface{}) []string {
 	for key, value := range params {
 		if strings.EqualFold(key, "X-Drone-Branches") {
 			return parseCommaSeparated(value)
@@ -19,7 +22,7 @@ func extractBranches(params map[string]string) []string {
 
 // helper function extracts the repository filters from the
 // secret payload in key value format.
-func extractRepos(params map[string]string) []string {
+func extractRepos(params map[string]interface{}) []string {
 	for key, value := range params {
 		if strings.EqualFold(key, "X-Drone-Repos") {
 			return parseCommaSeparated(value)
@@ -30,7 +33,7 @@ func extractRepos(params map[string]string) []string {
 
 // helper function extracts the event filters from the
 // secret payload in key value format.
-func extractEvents(params map[string]string) []string {
+func extractEvents(params map[string]interface{}) []string {
 	for key, value := range params {
 		if strings.EqualFold(key, "X-Drone-Events") {
 			return parseCommaSeparated(value)
@@ -39,8 +42,9 @@ func extractEvents(params map[string]string) []string {
 	return nil
 }
 
-func parseCommaSeparated(s string) []string {
-	parts := strings.Split(s, ",")
+func parseCommaSeparated(s interface{}) []string {
+	str := fmt.Sprintf("%v", s)
+	parts := strings.Split(str, ",")
 	if len(parts) == 1 && parts[0] == "" {
 		return nil
 	}

--- a/plugin/util_test.go
+++ b/plugin/util_test.go
@@ -9,6 +9,14 @@ import (
 	"testing"
 )
 
+func toInterface(testParams map[string]string) map[string]interface{}{
+	params := make(map[string]interface{}, len(testParams))
+	for k, v := range testParams {
+		params[k] = v
+	}
+	return params
+}
+
 func TestExtractBranches(t *testing.T) {
 	tests := []struct {
 		params   map[string]string
@@ -37,7 +45,8 @@ func TestExtractBranches(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		got, want := extractBranches(test.params), test.patterns
+		params := toInterface(test.params)
+		got, want := extractBranches(params), test.patterns
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("Unexpected results at %d", i)
 		}
@@ -72,7 +81,8 @@ func TestExtractRepos(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		got, want := extractRepos(test.params), test.patterns
+		params := toInterface(test.params)
+		got, want := extractRepos(params), test.patterns
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("Unexpected results at %d", i)
 		}
@@ -107,7 +117,8 @@ func TestExtractEvents(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		got, want := extractEvents(test.params), test.patterns
+		params := toInterface(test.params)
+		got, want := extractEvents(params), test.patterns
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("Unexpected results at %d", i)
 		}


### PR DESCRIPTION
This PR contains 2 main changes:

1. Give more context when a secret is not found, here the JSON unmarshalling error was swallowed and we were only seeing "secret no found". It was really hard to diagnose and I actually had to do this change and recompile to find out what the issue was.
2. While amazon secrets manager usually holds only string as secret value we ended up with integers in some places... automatically created by amazon RDS... I changed the code so that any type would be unmarshalled properly and then converted to a string. It's more flexible than failing completely to load the all secret map.

I'm not a Gopher so I apologize in advance for any wrong doing ;-)